### PR TITLE
Bump metrics-exporter-otel to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-otel"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "metrics",
  "metrics-util",
@@ -1389,9 +1389,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1402,15 +1402,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror",
  "tokio",
@@ -2300,19 +2301,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
- "tokio-macros",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ ndarray = { version = "0.16", default-features = false }
 ndarray-stats = { version = "0.6", default-features = false }
 noisy_float = { version = "0.2", default-features = false }
 once_cell = { version = "1", default-features = false, features = ["std"] }
-opentelemetry = { version = "0.31", default-features = false }
-opentelemetry_sdk = { version = "0.31", default-features = false }
+opentelemetry = { version = "0.32", default-features = false }
+opentelemetry_sdk = { version = "0.32", default-features = false }
 ordered-float = { version = "5", default-features = false }
 parking_lot = { version = "0.12", default-features = false }
 portable-atomic = { version = "1", default-features = false }

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
 metrics = "0.24"
-metrics-exporter-otel = "0.2"
-opentelemetry = "0.30"
-opentelemetry_sdk = "0.30"
+metrics-exporter-otel = "0.3"
+opentelemetry = "0.32"
+opentelemetry_sdk = "0.32"
 ```
 
 Basic usage:

--- a/metrics-exporter-otel/CHANGELOG.md
+++ b/metrics-exporter-otel/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.3.2]
+
+- Update `opentelemetry` and `opentelemetry_sdk` to `0.32`.
+
 ## [v0.3.1]
 
 - Optimize string allocations in storage

--- a/metrics-exporter-otel/Cargo.toml
+++ b/metrics-exporter-otel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metrics-exporter-otel"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.75.0"
 

--- a/metrics-exporter-otel/README.md
+++ b/metrics-exporter-otel/README.md
@@ -32,8 +32,8 @@ Add this to your `Cargo.toml`:
 [dependencies]
 metrics = "0.24"
 metrics-exporter-otel = "0.3"
-opentelemetry = "0.31"
-opentelemetry_sdk = "0.31"
+opentelemetry = "0.32"
+opentelemetry_sdk = "0.32"
 ```
 
 Basic usage:

--- a/metrics-exporter-otel/src/lib.rs
+++ b/metrics-exporter-otel/src/lib.rs
@@ -4,9 +4,9 @@
 
 mod instruments;
 mod metadata;
-mod storage;
 /// FIXME this module is for temporary patch of [metrics]
 mod metrics_ext;
+mod storage;
 
 use crate::metadata::MetricMetadata;
 use crate::storage::OtelMetricStorage;

--- a/metrics-exporter-otel/src/metrics_ext.rs
+++ b/metrics-exporter-otel/src/metrics_ext.rs
@@ -13,31 +13,31 @@ impl UnitExt for Unit {
     fn as_ucum_label(&self) -> &'static str {
         match self {
             // dimensionless
-            Unit::Count            => "1",
-            Unit::Percent          => "%",
+            Unit::Count => "1",
+            Unit::Percent => "%",
 
             // time
-            Unit::Seconds          => "s",
-            Unit::Milliseconds     => "ms",
-            Unit::Microseconds     => "us",
-            Unit::Nanoseconds      => "ns",
+            Unit::Seconds => "s",
+            Unit::Milliseconds => "ms",
+            Unit::Microseconds => "us",
+            Unit::Nanoseconds => "ns",
 
             // storage (binary prefixes)
-            Unit::Tebibytes        => "TiBy",
-            Unit::Gibibytes        => "GiBy",
-            Unit::Mebibytes        => "MiBy",
-            Unit::Kibibytes        => "KiBy",
-            Unit::Bytes            => "By",
+            Unit::Tebibytes => "TiBy",
+            Unit::Gibibytes => "GiBy",
+            Unit::Mebibytes => "MiBy",
+            Unit::Kibibytes => "KiBy",
+            Unit::Bytes => "By",
 
             // network throughput
             Unit::TerabitsPerSecond => "Tbit/s",
             Unit::GigabitsPerSecond => "Gbit/s",
             Unit::MegabitsPerSecond => "Mbit/s",
             Unit::KilobitsPerSecond => "kbit/s",
-            Unit::BitsPerSecond     => "bit/s",
+            Unit::BitsPerSecond => "bit/s",
 
             // event rate
-            Unit::CountPerSecond    => "1/s",
+            Unit::CountPerSecond => "1/s",
         }
     }
 }


### PR DESCRIPTION
## Summary
- Bump metrics-exporter-otel crate version to 0.3.2.
- Apply canonical cargo fmt output for existing formatting drift in the crate.